### PR TITLE
Preserve original call stack when re-throwing async exceptions.

### DIFF
--- a/TTWebClient/TickTraderWebClient.cs
+++ b/TTWebClient/TickTraderWebClient.cs
@@ -738,7 +738,7 @@ namespace TTWebClient
             {
                 AggregateException aggrex = ex.Flatten();
                 var inner = aggrex.InnerExceptions.FirstOrDefault();
-                throw inner ?? aggrex;
+                ExceptionDispatchInfo.Capture(inner ?? aggrex).Throw();
             }
         }
 
@@ -752,7 +752,8 @@ namespace TTWebClient
             {
                 AggregateException aggrex = ex.Flatten();
                 var inner = aggrex.InnerExceptions.FirstOrDefault();
-                throw inner ?? aggrex;
+                ExceptionDispatchInfo.Capture(inner ?? aggrex).Throw();
+                return default(TResult);
             }
         }
 


### PR DESCRIPTION
Preserve original call stack when re-throwing async exceptions. 
Duplicate code removal example.
